### PR TITLE
Use configurable defaults when no address is passed to the template tag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,12 @@ then create a EASY_MAPS_GOOGLE_KEY in your settings.py file::
 
     EASY_MAPS_GOOGLE_KEY = "your-google-maps-api-key"
 
+If you need a place where center the map when no address is inserted yet add the
+latitudine and longitude to the EASY_MAPS_CENTER variable in your settings.py
+like the following::
+
+    EASY_MAPS_CENTER = (-41.3, 32)
+
 Usage
 =====
 

--- a/easy_maps/templates/easy_maps/map.html
+++ b/easy_maps/templates/easy_maps/map.html
@@ -9,9 +9,7 @@
 {% block html %}
     <!-- HTML map container -->
     <div id="map-canvas-{{ map.pk }}"
-         {% if width and map.latitude and not map.geocode_error %}
-            style="width: {{ width }}px; height: {{ height }}px;"
-         {% endif %}
+         style="width: {{ width }}px; height: {{ height }}px;"
          class="easy-map-googlemap">
          {% block noscript %}
          <noscript>

--- a/easy_maps/templatetags/easy_maps_tags.py
+++ b/easy_maps/templatetags/easy_maps_tags.py
@@ -2,6 +2,8 @@
 from django import template
 from django.template.loader import render_to_string
 from easy_maps.models import Address
+from django.conf import settings
+
 register = template.Library()
 
 @register.tag
@@ -45,7 +47,12 @@ class EasyMapNode(template.Node):
             address = self.address.resolve(context)
             template_name = self.template_name.resolve(context)
 
-            map, _ = Address.objects.get_or_create(address=address or '')
+            map = None
+            if address == '':
+                map = Address(latitude=settings.EASY_MAPS_CENTER[0], longitude=settings.EASY_MAPS_CENTER[1])
+            else:
+                map, _ = Address.objects.get_or_create(address=address)
+
             context.update({
                 'map': map,
                 'width': self.width,

--- a/easy_maps/tests.py
+++ b/easy_maps/tests.py
@@ -1,0 +1,66 @@
+from django.test import TestCase
+from django.template import Template, Context
+import mock
+from django.test.utils import override_settings
+
+from .models import Address
+
+
+class AddressTests(TestCase):
+    fake_default_center  = (1, 2)
+    def test_empty_dont_save_on_db(self):
+        """If we pass an empty address we don't save nothing in the database"""
+        n_addresses_before = len(Address.objects.all())
+
+        simple_template_string = """{% load easy_maps_tags %}
+        {% easy_map "" 500 500 10 %}
+        """
+        t = Template(simple_template_string)
+        t.render(Context({}))
+
+
+        n_addresses_after = len(Address.objects.all())
+
+        self.assertEqual(n_addresses_after, n_addresses_before)
+
+    @override_settings(EASY_MAPS_CENTER=fake_default_center)
+    def test_empty_address_use_defaults(self):
+        """When an empty address is passed uses the EASY_MAPS_CENTER setting"""
+        a = ""
+        simple_template_string = """{%% load easy_maps_tags %%}
+        {%% easy_map "%s" 500 500 10 %%}
+        """ % a
+        self.address = None
+        # below we patch the render_to_string in order to retrieve the map
+        # context variable and check its coordinate
+        def get_map_context_instance(*args, **kwargs):
+            self.address = (kwargs['context_instance'].dicts[1])['map']
+            return ''
+
+        t = Template(simple_template_string)
+        with mock.patch('easy_maps.templatetags.easy_maps_tags.render_to_string', get_map_context_instance):
+            t.render(Context({}))
+
+        self.assertEqual(self.address.latitude, AddressTests.fake_default_center[0])
+        self.assertEqual(self.address.longitude, AddressTests.fake_default_center[1])
+
+    @override_settings(EASY_MAPS_CENTER=fake_default_center)
+    def test_normal_address(self):
+        """If we pass an address don't use the defaults"""
+        n_addresses_before = len(Address.objects.all())
+
+        a = "Ekaterinburg, Mira 33"
+        simple_template_string = """{%% load easy_maps_tags %%}
+        {%% easy_map "%s" 500 500 10 %%}
+        """ % a
+        t = Template(simple_template_string)
+        t.render(Context({}))
+
+        address = Address.objects.get(address=a)
+        self.assertNotEqual(address.latitude, AddressTests.fake_default_center[0])
+        self.assertNotEqual(address.longitude, AddressTests.fake_default_center[1])
+
+        n_addresses_after = len(Address.objects.all())
+
+        self.assertEqual(n_addresses_after, n_addresses_before + 1)
+

--- a/easy_maps_tests/settings.py
+++ b/easy_maps_tests/settings.py
@@ -28,3 +28,5 @@ INSTALLED_APPS=(
 #    'devserver',
     'south',
 )
+
+EASY_MAPS_CENTER = (45.0677201, 7.6825531)


### PR DESCRIPTION
With this changes no instance with empty address is saved into the db and is possible to indicate some geographical coordinate with which center the map when no address is indicated.

Some tests added.
