### PR TITLE
Allow to display more than one marker

### DIFF
--- a/easy_maps/templatetags/easy_maps_tags.py
+++ b/easy_maps/templatetags/easy_maps_tags.py
@@ -46,24 +46,21 @@ class EasyMapNode(template.Node):
         self.template_name = template.Variable(template_name or '"easy_maps/map.html"')
 
     def render(self, context):
-        try:
-            address = self.address.resolve(context)
-            template_name = self.template_name.resolve(context)
+        address = self.address.resolve(context)
+        template_name = self.template_name.resolve(context)
 
-            map = address
-            if not isinstance(address, Address):
-                if address == '':
-                    map = Address(latitude=settings.EASY_MAPS_CENTER[0], longitude=settings.EASY_MAPS_CENTER[1])
-                else:
-                    map, _ = Address.objects.get_or_create(address=address)
+        map = address
+        if not isinstance(address, Address):
+            if address == '':
+                map = Address(latitude=settings.EASY_MAPS_CENTER[0], longitude=settings.EASY_MAPS_CENTER[1])
+            else:
+                map, _ = Address.objects.get_or_create(address=address)
 
-            context.update({
-                'map': map,
-                'width': self.width,
-                'height': self.height,
-                'zoom': self.zoom,
-                'template_name': template_name
-            })
-            return render_to_string(template_name, context_instance=context)
-        except template.VariableDoesNotExist:
-            return ''
+        context.update({
+            'map': map,
+            'width': self.width,
+            'height': self.height,
+            'zoom': self.zoom,
+            'template_name': template_name
+        })
+        return render_to_string(template_name, context_instance=context)

--- a/easy_maps/templatetags/easy_maps_tags.py
+++ b/easy_maps/templatetags/easy_maps_tags.py
@@ -11,6 +11,9 @@ def easy_map(parser, token):
     """
     The syntax:
         {% easy_map <address> [<width> <height>] [<zoom>] [using <template_name>] %}
+
+    The "address" parameter can be an Address instance or a string describing it.
+    If an address is not found a new entry is created in the database.
     """
     width, height, zoom, template_name = None, None, None, None
     params = token.split_contents()
@@ -47,11 +50,12 @@ class EasyMapNode(template.Node):
             address = self.address.resolve(context)
             template_name = self.template_name.resolve(context)
 
-            map = None
-            if address == '':
-                map = Address(latitude=settings.EASY_MAPS_CENTER[0], longitude=settings.EASY_MAPS_CENTER[1])
-            else:
-                map, _ = Address.objects.get_or_create(address=address)
+            map = address
+            if not isinstance(address, Address):
+                if address == '':
+                    map = Address(latitude=settings.EASY_MAPS_CENTER[0], longitude=settings.EASY_MAPS_CENTER[1])
+                else:
+                    map, _ = Address.objects.get_or_create(address=address)
 
             context.update({
                 'map': map,

--- a/easy_maps_tests/test_app/tests.py
+++ b/easy_maps_tests/test_app/tests.py
@@ -64,3 +64,25 @@ class AddressTests(TestCase):
 
         self.assertEqual(n_addresses_after, n_addresses_before + 1)
 
+    @override_settings(EASY_MAPS_CENTER=fake_default_center)
+    def test_use_address_instance(self):
+        """It's possible to pass directly to the easy_map tag an Address instance.
+
+        This test checks also that the database is not hit.
+        """
+        # create a fake address
+        Address.objects.create(address='fake')
+        n_addresses_before = len(Address.objects.all())
+
+        simple_template_string = """{% load easy_maps_tags %}
+        {% easy_map address 500 500 10 %}
+        """
+        address = Address.objects.all()[0]
+        t = Template(simple_template_string)
+        # this assert works only from django1.3
+        self.assertNumQueries(0, lambda: t.render(Context({'address': address,})))
+
+        n_addresses_after = len(Address.objects.all())
+
+        # no Address is created in the process
+        self.assertEqual(n_addresses_after, n_addresses_before)


### PR DESCRIPTION
This is a work in progress, I think first of all to allow Address instance to be passed as argument of easy_map tag and this is implemented in b747055.

This is also useful since if we render the tag from already saved instances, using their descriptions to retrieve them from the database is a waste of resources.

The second step will be of allow to pass a list of addresses, either as string either as Address instances.
