### PR TITLE
Use google geocoder v3.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Installation
 
 ::
 
-    pip install geopy
+    pip install geopy==0.95
     pip install django-easy-maps
 
 Then add 'easy_maps' to INSTALLED_APPS and run ``./manage.py syncdb``

--- a/easy_maps/models.py
+++ b/easy_maps/models.py
@@ -16,9 +16,9 @@ class Address(models.Model):
             return
         try:
             if hasattr(settings, "EASY_MAPS_GOOGLE_KEY") and settings.EASY_MAPS_GOOGLE_KEY:
-                g = geocoders.Google(settings.EASY_MAPS_GOOGLE_KEY)
+                g = geocoders.GoogleV3()
             else:
-                g = geocoders.Google(resource='maps')
+                g = geocoders.GoogleV3()
             address = smart_str(self.address)
             self.computed_address, (self.latitude, self.longitude,) = g.geocode(address, exactly_one=False)[0]
             self.geocode_error = False


### PR DESCRIPTION
Since from the Google Maps Api's documentation we know that from May 2013 the v2 of this API will be dismissed, we use the v3. In order to use them we have to use at least geopy 0.95.

I'm using the development version of geopy on github, the 0.95 version seems to not be rolled out yet.
