### PR TITLE
Add Google Maps API key configuration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,8 +55,15 @@ needs to be applied:
 
     ./manage.py migrate easy_maps 0001 --fake
 
-Configuration (optional)
-------------------------
+Configuration
+-------------
+
+The only mandatory configuration is the
+``EASY_MAPS_GOOGLE_MAPS_API_KEY`` variable:
+
+.. code-block:: python
+
+    EASY_MAPS_GOOGLE_MAPS_API_KEY = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ___0123456789'
 
 If you need a place to center the map at when no address is inserted
 yet, add the latitude and longitude to the ``EASY_MAPS_CENTER`` variable in

--- a/easy_maps/conf.py
+++ b/easy_maps/conf.py
@@ -7,6 +7,7 @@ from appconf import AppConf
 class EasyMapsSettings(AppConf):
     CENTER = (-41.3, 32)
     GEOCODE = 'easy_maps.geocode.google_v3'
+    GOOGLE_MAPS_API_KEY = None
 
     class Meta:
         prefix = 'easy_maps'

--- a/easy_maps/templates/easy_maps/map.html
+++ b/easy_maps/templates/easy_maps/map.html
@@ -1,7 +1,7 @@
 {% with map.latitude|stringformat:"f" as lat %}{% with map.longitude|stringformat:"f" as long %}
 
 {% block api_js %}
-  <script type="text/javascript" src="https://maps.google.com/maps/api/js?sensor=false"></script>
+  <script type="text/javascript" src="https://maps.google.com/maps/api/js?sensor=false&key={{ key }}"></script>
 {% endblock %}
 
 {% block html %}
@@ -13,7 +13,7 @@
     class="easy-map-googlemap">
     {% block noscript %}{% if map.computed_address %}
       <noscript>
-        <img alt="Map of {{ map.address }}" src="https://maps.google.com/maps/api/staticmap?center={{ lat }},{{ long }}&zoom={{ zoom }}&markers={{ lat }},{{ long }}&size={{ width|default:"320" }}x{{ height|default:"240" }}&sensor=false">
+        <img alt="Map of {{ map.address }}" src="https://maps.google.com/maps/api/staticmap?center={{ lat }},{{ long }}&zoom={{ zoom }}&markers={{ lat }},{{ long }}&size={{ width|default:"320" }}x{{ height|default:"240" }}&sensor=false&key={{ key }}">
       </noscript>
     {% endif %}{% endblock %}
     {% if not map.computed_address %}<!-- geocoding error -->{% endif %}


### PR DESCRIPTION
EASY_MAPS_GOOGLE_MAPS_API_KEY is now used to configure
the application keys that are used to access the
Google Maps API as per new Google Maps regulations
