### PR TITLE
geocode API key

### DIFF
--- a/easy_maps/geocode.py
+++ b/easy_maps/geocode.py
@@ -4,6 +4,7 @@ from django.utils.encoding import smart_str
 
 from geopy import geocoders
 from geopy.exc import GeocoderServiceError
+from .conf import settings
 
 
 class Error(Exception):
@@ -17,7 +18,7 @@ def google_v3(address):
 
     """
     try:
-        g = geocoders.GoogleV3()
+        g = geocoders.GoogleV3(api_key=settings.EASY_MAPS_GOOGLE_MAPS_API_KEY)
 
         results = g.geocode(smart_str(address), exactly_one=False)
         if results is not None:


### PR DESCRIPTION
The API key is only used in JavaScript. The python calls were not using the API key. Google is locking it down now where you need the key.