### PR TITLE
Check if EASY_MAPS_GOOGLE_MAPS_API_KEY is not None before raising warning.

### DIFF
--- a/easy_maps/conf.py
+++ b/easy_maps/conf.py
@@ -21,5 +21,5 @@ class EasyMapsSettings(AppConf):
         prefix = 'easy_maps'
         holder = 'easy_maps.conf.settings'
 
-if hasattr(settings, 'EASY_MAPS_GOOGLE_MAPS_API_KEY'):
+if settings.EASY_MAPS_GOOGLE_MAPS_API_KEY is not None:
     warnings.warn("EASY_MAPS_GOOGLE_MAPS_API_KEY is deprecated, use EASY_MAPS_GOOGLE_KEY", DeprecationWarning)


### PR DESCRIPTION
We've got an issue with rather annoying warning from easy_maps being risen even though we're not using `EASY_MAPS_GOOGLE_MAPS_API_KEY` anymore:

```
/home/ngaranko/.virtualenvs/project/local/lib/python2.7/site-packages/easy_maps/conf.py:25: DeprecationWarning: EASY_MAPS_GOOGLE_MAPS_API_KEY is deprecated, use EASY_MAPS_GOOGLE_KEY
  warnings.warn("EASY_MAPS_GOOGLE_MAPS_API_KEY is deprecated, use EASY_MAPS_GOOGLE_KEY", DeprecationWarning)
```

This is caused by `AppConf` setting `EASY_MAPS_GOOGLE_MAPS_API_KEY` to `None` via https://github.com/bashu/django-easy-maps/blob/develop/easy_maps/conf.py#L15

Cheers,
Nick