### PR TITLE
add Django 3.0 support

### DIFF
--- a/easy_maps/__init__.py
+++ b/easy_maps/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.2"
+__version__ = "1.1.0"
 
 import warnings
 

--- a/easy_maps/models.py
+++ b/easy_maps/models.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 
 from django.db import models
 from django.utils import timezone
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
 from . import geocode

--- a/setup.py
+++ b/setup.py
@@ -43,9 +43,10 @@ setup(
         'django-classy-tags>=0.6.2',
         'django-appconf',
         'geopy>=0.96',
+        'six>=1.9.0'
     ],
     requires=[
-        'Django (>=1.4.2)',
+        'Django (>=1.11.0)',
     ],
 
     description="This app makes it easy to display a map for a given address",


### PR DESCRIPTION
python_2_unicode_compatible moved to external six library.

Should be removed after dropping support of python 2.7